### PR TITLE
Iterowanie po słowniku z items() zamiast iteritems() - zgodność z Pyt…

### DIFF
--- a/templates/app/env.d/virtualenv.conf.j2
+++ b/templates/app/env.d/virtualenv.conf.j2
@@ -2,7 +2,7 @@
 
 # based on python_deploy__environment_venv:
 
-{% for key, value in python_deploy__environment_venv.iteritems() %}
+{% for key, value in python_deploy__environment_venv.items() %}
 {{ key }}={{ value }}
 {% endfor %}
 


### PR DESCRIPTION
Błąd wyskakuje, jeżeli używa się venv'a ansible/debops z Pythonem 3.x. `items` działa na 2.7 i 3.x.